### PR TITLE
fix error if CUI does not exist as attribute of concept

### DIFF
--- a/negbio/pipeline/dner_mm.py
+++ b/negbio/pipeline/dner_mm.py
@@ -68,8 +68,11 @@ def run_metamap_col(collection, mm, cuis=None):
             for concept in concepts:
                 concept_index = adapt_concept_index(concept.index)
                 try:
-                    if cuis is not None and concept.cui not in cuis:
-                        continue
+                    if cuis is not None:
+                        # if no CUI is returned for this concept - skip it
+                        concept_cui = getattr(concept, 'cui', None)
+                        if concept_cui not in cuis:
+                            continue
                     m = re.match(r'(\d+)/(\d+)', concept.pos_info)
                     if m:
                         passage = sentence_map[concept_index][0]


### PR DESCRIPTION
I get the following error when using negbio on the simple phrase `fluorodeoxyglucose (FDG)`:

```
File "/home/alistairewj/git/NegBio/negbio/pipeline/dner_mm.py", line 71, in run_metamap_col
    if cuis is not None and concept.cui not in cuis:
AttributeError: 'ConceptAA' object has no attribute 'cui'
```

It seems as though MetaMap sometimes returns an object with no CUIs, e.g. in my case I got this concept:

`ConceptAA(index="'tmp2-0'", aa='AA', short_form='FDG', long_form='fluorodeoxyglucose', num_tokens_short_form='1', num_chars_short_form='3', num_tokens_long_form='1', num_chars_long_form='18', pos_info='21:3')`

Using `getattr` avoids the issue by skipping the concept if no CUI exists - in my mind this seems reasonable to do but up to you - maybe there is a deeper problem with metamap not assigning CUIs when it should.