### PR TITLE
Fix errors and reformat ptb2ud.py

### DIFF
--- a/negbio/pipeline/parse.py
+++ b/negbio/pipeline/parse.py
@@ -30,9 +30,13 @@ class Bllip(object):
         """
         if not s:
             raise ValueError('Cannot parse empty sentence: {}'.format(s))
+
         try:
             nbest = self.rrp.parse(str(s))
-            return nbest[0].ptb_parse
+            if nbest:
+                return nbest[0].ptb_parse
+            else:
+                return None
         except:
             raise ValueError('Cannot parse sentence: %s' % s)
 
@@ -53,7 +57,11 @@ class NegBioParser(Bllip):
                 try:
                     text = sentence.text
                     tree = self.parse(text)
-                    sentence.infons['parse tree'] = str(tree)
+                    if tree:
+                        sentence.infons['parse tree'] = str(tree)
+                    else:
+                        sentence.infons['parse tree'] = None
                 except:
-                    logging.exception('Cannot parse sentence: {}'.format(sentence.offset))
+                    logging.exception(
+                        'Cannot parse sentence: {}'.format(sentence.offset))
         return document

--- a/negbio/pipeline/parse.py
+++ b/negbio/pipeline/parse.py
@@ -31,14 +31,11 @@ class Bllip(object):
         if not s:
             raise ValueError('Cannot parse empty sentence: {}'.format(s))
 
-        try:
-            nbest = self.rrp.parse(str(s))
-            if nbest:
-                return nbest[0].ptb_parse
-            else:
-                return None
-        except:
-            raise ValueError('Cannot parse sentence: %s' % s)
+        nbest = self.rrp.parse(str(s))
+        if nbest:
+            return nbest[0].ptb_parse
+
+        return None
 
 
 class NegBioParser(Bllip):
@@ -54,14 +51,12 @@ class NegBioParser(Bllip):
         """
         for passage in document.passages:
             for sentence in passage.sentences:
-                try:
-                    text = sentence.text
-                    tree = self.parse(text)
-                    if tree:
-                        sentence.infons['parse tree'] = str(tree)
-                    else:
-                        sentence.infons['parse tree'] = None
-                except:
+                text = sentence.text
+                tree = self.parse(text)
+                if tree:
+                    sentence.infons['parse tree'] = str(tree)
+                else:
+                    sentence.infons['parse tree'] = None
                     logging.exception(
-                        'Cannot parse sentence: {}'.format(sentence.offset))
+                        'No parse tree for sentence: %s', sentence.offset)
         return document

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -108,7 +108,8 @@ class NegBioPtb2DepConverter(Ptb2DepConverter):
                     dependency_graph = self.convert(
                         sentence.infons['parse tree'])
                     anns, rels = convert_dg(dependency_graph, sentence.text,
-                                            sentence.offset, self.add_lemmas)
+                                            sentence.offset,
+                                            has_lemmas=self.add_lemmas)
                     sentence.annotations = anns
                     sentence.relations = rels
                 except:

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -107,12 +107,8 @@ class NegBioPtb2DepConverter(Ptb2DepConverter):
                 # check for empty infons, don't process if empty
                 # this sometimes happens with poorly tokenized sentences
                 if not sentence.infons:
-                    logging.warning(
-                        "No parse information for sentence %d in %s", sentence.offset, document.id)
                     continue
                 elif not sentence.infons['parse tree']:
-                    logging.warning(
-                        "No parse tree for sentence %d in %s", sentence.offset, document.id)
                     continue
 
                 try:

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -112,6 +112,8 @@ class NegBioPtb2DepConverter(Ptb2DepConverter):
                                             has_lemmas=self.add_lemmas)
                     sentence.annotations = anns
                     sentence.relations = rels
+                except KeyboardInterrupt:
+                    raise
                 except:
                     logging.exception(
                         "Cannot process sentence %d in %s", sentence.offset, document.id)

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -51,7 +51,7 @@ class Ptb2DepConverter(object):
 
     basic = 'basic'
     collapsed = 'collapsed'
-    CCprocessed = 'CCprocessed',
+    CCprocessed = 'CCprocessed'
     collapsedTree = 'collapsedTree'
 
     def __init__(self, lemmatizer, representation='CCprocessed', universal=False):

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -104,6 +104,17 @@ class NegBioPtb2DepConverter(Ptb2DepConverter):
     def convert_doc(self, document):
         for passage in document.passages:
             for sentence in passage.sentences:
+                # check for empty infons, don't process if empty
+                # this sometimes happens with poorly tokenized sentences
+                if not sentence.infons:
+                    logging.warning(
+                        "No parse information for sentence %d in %s", sentence.offset, document.id)
+                    continue
+                elif not sentence.infons['parse tree']:
+                    logging.warning(
+                        "No parse tree for sentence %d in %s", sentence.offset, document.id)
+                    continue
+
                 try:
                     dependency_graph = self.convert(
                         sentence.infons['parse tree'])

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -98,19 +98,22 @@ class NegBioPtb2DepConverter(Ptb2DepConverter):
         Args:
             lemmatizer (Lemmatizer)
         """
-        super(NegBioPtb2DepConverter, self).__init__(lemmatizer, representation, universal)
+        super(NegBioPtb2DepConverter, self).__init__(
+            lemmatizer, representation, universal)
 
     def convert_doc(self, document):
         for passage in document.passages:
             for sentence in passage.sentences:
                 try:
-                    dependency_graph = self.convert(sentence.infons['parse tree'])
-                    anns, rels = convert_dg(dependency_graph, sentence.text, sentence.offset,
-                                            self.add_lemmas)
+                    dependency_graph = self.convert(
+                        sentence.infons['parse tree'])
+                    anns, rels = convert_dg(dependency_graph, sentence.text,
+                                            sentence.offset, self.add_lemmas)
                     sentence.annotations = anns
                     sentence.relations = rels
                 except:
-                    logging.exception("Cannot process sentence %d in %s", sentence.offset, document.id)
+                    logging.exception(
+                        "Cannot process sentence %d in %s", sentence.offset, document.id)
 
                 if not self.add_lemmas:
                     for ann in sentence.annotations:
@@ -188,8 +191,10 @@ def convert_dg(dependency_graph, text, offset, ann_index=0, rel_index=0, has_lem
         relation.infons['dependency'] = node.deprel
         if node.extra:
             relation.infons['extra'] = node.extra
-        relation.add_node(bioc.BioCNode('T{}'.format(annotation_id_map[node.index]), 'dependant'))
-        relation.add_node(bioc.BioCNode('T{}'.format(annotation_id_map[node.head]), 'governor'))
+        relation.add_node(bioc.BioCNode('T{}'.format(
+            annotation_id_map[node.index]), 'dependant'))
+        relation.add_node(bioc.BioCNode('T{}'.format(
+            annotation_id_map[node.head]), 'governor'))
         relations.append(relation)
         rel_index += 1
 


### PR DESCRIPTION
Sometimes ptb2ud.py would raise the following error:

```
Traceback (most recent call last):
  File "NegBio/negbio/pipeline/ptb2ud.py", line 109, in convert_doc
    self.add_lemmas)
  File "NegBio/negbio/pipeline/ptb2ud.py", line 183, in convert_dg
    ann = annotations[annotation_id_map[node.index]]
IndexError: list index out of range
```

Fairly sure this was due to self.add_lemmas being interpreted as an annotation offset in the new code, which I've fixed in this PR. I also took the opportunity to change the try/except to not continue the loop on keyboard interrupt.