### PR TITLE
Minor fixes for parse/handling paths

### DIFF
--- a/negbio/pipeline/parse.py
+++ b/negbio/pipeline/parse.py
@@ -14,6 +14,9 @@ class Bllip(object):
             logging.debug("downloading GENIA+PubMed model if necessary ...")
             model_dir = ModelFetcher.download_and_install_model(
                 'GENIA+PubMed', os.path.join(tempfile.gettempdir(), 'models'))
+        elif 'pathlib' in str(type(model_dir)):
+            # avoid python 2/3 compatibility issues with os/pathlib2
+            model_dir = str(model_dir)
         self.model_dir = os.path.expanduser(model_dir)
 
         logging.debug('loading model %s ...' % self.model_dir)

--- a/negbio/pipeline/ptb2ud.py
+++ b/negbio/pipeline/ptb2ud.py
@@ -174,7 +174,7 @@ def convert_dg(dependency_graph, text, offset, ann_index=0, rel_index=0, has_lem
             if index == -1:
                 logging.debug('Cannot convert parse tree to dependency graph at %d\n%d\n%s',
                               start, offset, str(dependency_graph))
-                return
+                return None, None
 
         ann = bioc.BioCAnnotation()
         ann.id = 'T{}'.format(ann_index)


### PR DESCRIPTION
1. if the code could not parse the sentence, it would return `None`, but should return `None, None` to be consistent
2. Using a `pathlib2` path for model_dir throws an error as `pathlib2` doesn't fully replicate behaviour with `os` functions in python 3