### PR TITLE
JPype1 version: 0.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ bioc==1.1.dev3
 pystanforddependencies==0.3.1
 bllipparser==2016.9.11
 pymetamap==0.1
-JPype1>=0.6.3
+JPype1==0.6.3
 pathlib2==2.3.3
 numpy==1.15.4


### PR DESCRIPTION
JPype1 has released version 0.7 as mentioned in https://github.com/jpype-project/jpype/releases

For the issue: https://github.com/ncbi-nlp/NegBio/issues/27 it was [mentioned](https://github.com/jpype-project/jpype/issues/395#issuecomment-502723967) that JPype1 version: 0.7 would resolve the issue
I tried testing(in usual way by executing main_mm.py without Flask)  using the updated release of JPype1. But found that negation is not at all coming in the output.

Haven't debugged the reason yet. Will do it later. For now, reverting back JPype1 version mentioned in NegBio to 0.6.3 on which it was working earlier so that others don't face any issue.